### PR TITLE
Fix any type error in debates api

### DIFF
--- a/src/app/api/debates/route.ts
+++ b/src/app/api/debates/route.ts
@@ -62,7 +62,7 @@ export async function GET() {
 export async function POST(req: Request) {
   let userId: string | undefined;
   let topic: string | undefined;
-  let requestBody: any;
+  let requestBody: unknown;
   
   try {
     console.log('🚀 POST /api/debates - Starting debate creation');


### PR DESCRIPTION
Replace `any` with `unknown` for `requestBody` to fix ESLint error and improve type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ec7d70a-84a0-41f9-afe8-ec47b2bfffb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ec7d70a-84a0-41f9-afe8-ec47b2bfffb3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>