### PR TITLE
Fix ai feedback display in ui

### DIFF
--- a/src/app/debates/[id]/page.tsx
+++ b/src/app/debates/[id]/page.tsx
@@ -108,6 +108,13 @@ export default function DebatePage() {
           const data = await res.json()
           setDebate(data)
           setDebateStatus(data.status || "waiting")
+          
+          // Load AI feedback if debate is already completed
+          if (data.status === "completed" && data.aiFeedback) {
+            setAiFeedback(data.aiFeedback)
+            console.log("✅ Loaded existing AI feedback:", data.aiFeedback)
+          }
+          
           if (user?.id) {
             if (data.proUser?.clerkId === user.id) {
               setRole("pro")
@@ -130,7 +137,11 @@ export default function DebatePage() {
   }, [id, user?.id])
 
   useEffect(() => {
-    if (!socket) return
+    if (!socket || !id || !user?.id) return
+
+    // Join the debate room to receive real-time updates
+    socket.emit("join_debate", { debateId: id, userId: user.id, role })
+    console.log(`🔌 Joined debate room: debate_${id} as ${role}`)
 
     const onStarted = ({ duration }: { duration: number }) => {
       console.log("✅ Debate started:", { duration })
@@ -176,7 +187,7 @@ export default function DebatePage() {
       socket.off("debate_feedback", onFeedback)
       socket.off("error", onError)
     }
-  }, [socket, debateStatus])
+  }, [socket, debateStatus, id, user?.id, role])
 
   useEffect(() => {
     if (debateStatus === "completed" && feedbackLoading && !aiFeedback) {

--- a/src/components/DebateRoom.tsx
+++ b/src/components/DebateRoom.tsx
@@ -161,9 +161,11 @@ export default function DebateRoom({
   }, [debateStatus, startTime, fetchedDuration]);
 
   useEffect(() => {
-    // Join the debate room on mount if socket is available and user is pro or con
-    if (socket && debateId && (isPro || isCon)) {
-      socket.emit("join_debate", { debateId, userId, role: isPro ? "pro" : "con" });
+    // Join the debate room on mount if socket is available
+    if (socket && debateId && userId) {
+      const userRole = isPro ? "pro" : isCon ? "con" : "viewer";
+      socket.emit("join_debate", { debateId, userId, role: userRole });
+      console.log(`🔌 DebateRoom joined debate room: debate_${debateId} as ${userRole}`);
     }
   }, [socket, debateId, userId, isPro, isCon]);
 


### PR DESCRIPTION
Display AI feedback in the UI by ensuring the debate page joins the socket room and loads existing feedback.

The main debate page was not joining the specific socket room where AI feedback events were emitted, preventing real-time updates. Additionally, for debates already completed, the AI feedback was not loaded upon initial page render. This PR addresses both issues and ensures all user roles can receive feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-f70e98b4-6fc3-47ce-9b0a-2c063b047a01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f70e98b4-6fc3-47ce-9b0a-2c063b047a01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

